### PR TITLE
mark as "task done" for syncronized tasks

### DIFF
--- a/workflow/patterns/controlflow.py
+++ b/workflow/patterns/controlflow.py
@@ -507,3 +507,4 @@ class MySpecialThread(threading.Thread):
     def run(self):
         call = self.itemq.get()
         call()
+        self.itemq.task_done()


### PR DESCRIPTION
When using `patterns.SYNCHRONIZE`, the process is stopped and never executes the last step, causing a timeout exception.